### PR TITLE
Implement property indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 coverage
 lib
 node_modules
-*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 coverage
 lib
 node_modules
+*.tgz

--- a/package.json
+++ b/package.json
@@ -56,18 +56,18 @@
     "url": "https://github.com/bouzuya/cookie-storage.git"
   },
   "scripts": {
-    "build": "npm-run-all -s 'build:ts' 'build:es2015' -p 'copy:*'",
+    "build": "npm-run-all -s build:ts build:es2015 -p copy:*",
     "build:es2015": "babel --out-dir .tmp/es5/ .tmp/es2015/",
     "build:ts": "tsc",
     "clean": "rimraf .tmp lib",
     "copy:dts": "cpx '.tmp/es2015/src/**/*.d.ts' 'lib/'",
     "copy:js": "cpx '.tmp/es5/src/**/*.js' 'lib/'",
-    "prepublish": "npm-run-all -s 'clean' 'build'",
+    "prepublish": "npm-run-all -s clean build",
     "test": "beater",
-    "watch": "npm-run-all -p 'watch:*'",
-    "watch:es2015": "npm run 'build:es2015' -- --watch",
-    "watch:test": "watch --wait 2 'npm test' '.tmp/es5/'",
-    "watch:ts": "npm run 'build:ts' -- --watch"
+    "watch": "npm-run-all -p watch:*",
+    "watch:es2015": "npm run build:es2015 -- --watch",
+    "watch:test": "watch --wait 2 \"npm test\" \".tmp/es5/\"",
+    "watch:ts": "npm run build:ts -- --watch"
   },
   "typings": "./lib/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "proxyquire": "1.7.10",
     "rimraf": "2.5.4",
     "sinon": "1.17.5",
-    "typescript": "2.0.2",
+    "typescript": "2.3.2",
     "watch": "0.19.2"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "proxyquire": "1.7.10",
     "rimraf": "2.5.4",
     "sinon": "1.17.5",
-    "typescript": "2.3.2",
+    "typescript": "2.0.2",
     "watch": "0.19.2"
   },
   "files": [

--- a/src/cookie-storage.ts
+++ b/src/cookie-storage.ts
@@ -62,4 +62,7 @@ export class CookieStorage implements Storage {
   private _setCookie(value: string): void {
     document.cookie = value;
   }
+
+  [key: string]: any;
+  [index: number]: string;
 }

--- a/src/cookie-storage.ts
+++ b/src/cookie-storage.ts
@@ -13,7 +13,9 @@ export class CookieStorage implements Storage {
       expires: null,
       secure: false
     }, defaultOptions);
-    return new Proxy(this, CookieStorageHandler);
+    if (ProxyIsSupported()) {
+        return new Proxy(this, CookieStorageHandler);
+    }   
   }
 
   get length(): number {
@@ -136,5 +138,15 @@ var CookieStorageHandler: ProxyHandler<CookieStorage> = {
                 configurable: true
             };
         }
+    }
+};
+
+export function ProxyIsSupported(): boolean {
+    try {
+        new Proxy({}, {});
+        return true;
+    }
+    catch(e) {
+        return false;
     }
 };

--- a/src/cookie-storage.ts
+++ b/src/cookie-storage.ts
@@ -48,8 +48,8 @@ export class CookieStorage implements Storage {
   }
 
   setItem(key: string, data: string, options?: CookieOptions): void {
-    options = Object.assign({}, this._defaultOptions, options);
-    const formatted = formatCookie(key, data, options);
+    const _options: CookieOptions = Object.assign({}, this._defaultOptions, options);
+    const formatted = formatCookie(key, data, _options);
     this._setCookie(formatted);
   }
 

--- a/src/cookie-storage.ts
+++ b/src/cookie-storage.ts
@@ -49,8 +49,8 @@ export class CookieStorage implements Storage {
   }
 
   setItem(key: string, data: string, options?: CookieOptions): void {
-    const _options: CookieOptions = Object.assign({}, this._defaultOptions, options);
-    const formatted = formatCookie(key, data, _options);
+    options = Object.assign({}, this._defaultOptions, options);
+    const formatted = formatCookie(key, data, options);
     this._setCookie(formatted);
   }
 

--- a/src/cookie-storage.ts
+++ b/src/cookie-storage.ts
@@ -13,6 +13,7 @@ export class CookieStorage implements Storage {
       expires: null,
       secure: false
     }, defaultOptions);
+    return new Proxy(this, CookieStorageHandler);
   }
 
   get length(): number {
@@ -66,3 +67,85 @@ export class CookieStorage implements Storage {
   [key: string]: any;
   [index: number]: string;
 }
+
+var CookieStorageHandler: ProxyHandler<CookieStorage> = {
+    //getPrototypeOf? (target: T): object | null;
+        //Need to investigate
+    //setPrototypeOf? (target: T, v: any): boolean;
+        //Need to investigate
+    //isExtensible? (target: T): boolean;
+        //not necessary to implement. Calling Object.isExtensible(p); works correctly with no modifications on the proxy object.
+    //preventExtensions? (target: T): boolean;
+        //not necessary to implement. Calling Object.preventExtensions(p); works correctly with no modifications on the proxy object.
+    //getOwnPropertyDescriptor? (target: T, p: PropertyKey): PropertyDescriptor;
+        //not necessary to emulate LocalStorage and SessionStorage - both of those methods basically ignore propertyDescritors when setting. However, it seems to be nice!
+    getOwnPropertyDescriptor(target, p) {
+        return Object.getOwnPropertyDescriptor(target, p);
+    },
+    //has? (target: T, p: PropertyKey): boolean;
+    has(target, p) {
+        return target.getItem(p.toString()) ? true : false;
+    },
+    //get? (target: T, p: PropertyKey, receiver: any): any;
+    get(target, p) {
+        if (p in target) {
+            return target[p];
+        }
+        else {
+            let result = target.getItem(p.toString())
+            return result ? result : undefined;
+        }
+    },
+    //set? (target: T, p: PropertyKey, value: any, receiver: any): boolean;
+    set(target, p, value) {
+        let isExtensible = Object.isExtensible(target);
+        let alreadyExists = target.getItem(p.toString());
+        if (!isExtensible && alreadyExists) {
+            //"Attempting to add new properties to a non-extensible object will fail, either silently or by throwing a TypeError (most commonly, but not exclusively, when in strict mode)."
+            //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions
+            throw new TypeError("Can't add property " + p.toString() + ", object is not extensible");
+        }
+        else {
+            target.setItem(p.toString(), value);
+            return true;
+        }
+    },
+    //deleteProperty? (target: T, p: PropertyKey): boolean;
+    deleteProperty(target, p) {
+        target.removeItem(p.toString());
+        return true;
+    },
+    //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/defineProperty
+    defineProperty(target, p, attributes) {
+        let isExtensible = Object.isExtensible(target);
+        let alreadyExists = target.getItem(p.toString());
+        //If the following invariants are violated, the proxy will throw a TypeError:
+        //--A property cannot be added, if the target object is not extensible."
+        //--A property cannot be added as or modified to be non-configurable, if it does not exists as a non-configurable own property of the target object.
+        //--A property may not be non-configurable, if a corresponding configurable property of the target object exists.
+        //--If a property has a corresponding target object property then Object.defineProperty(target, prop, descriptor) will not throw an exception.
+        //--In strict mode, a false return value from the defineProperty handler will throw a TypeError exception.
+        if (!isExtensible && alreadyExists) {
+            throw new TypeError("Can't add property " + p.toString() + ", object is not extensible");
+        }
+        else {
+            Object.defineProperty(target, p, attributes);
+            target.setItem(p.toString(), attributes.value);
+            return true;
+        }
+    },
+    //enumerate? (target: T): PropertyKey[];
+        //obsolete: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/enumerate
+    //ownKeys? (target: T): PropertyKey[];
+    ownKeys(target) {
+        //todo: this code is duplicated from the private _getCookie() method on the CookieStorage object. I need to find the right pattern so you don't have to duplicate this private method in the proxy object.
+        //todo: I only added this line because I got a complier warning "target was declared but never used". Need to find a better way to remove this
+        console.log(target);
+        const parsed = parseCookies(document.cookie);
+        return Object.keys(parsed);
+    },
+    //apply? (target: T, thisArg: any, argArray?: any): any;
+        //not applicable to proxies for clasess, only proxies to functions
+    //construct? (target: T, argArray: any, newTarget?: any): object;
+        //overrides the new operator. Might not be necessary
+};

--- a/src/cookie-storage.ts
+++ b/src/cookie-storage.ts
@@ -130,9 +130,6 @@ var CookieStorageHandler: ProxyHandler<CookieStorage> = {
             throw new TypeError("Can't add property " + p.toString() + ", object is not extensible");
         }
         else {
-            //Todo: maybe don't actually define a property? This is the only way to get "attributes" to be perserved, but localStorage doesn't do this.
-            //Actually, this is probably a bad idea, since it seems to mess up Object.keys() and isn't how localStorage behaves.
-            //Object.defineProperty(target, p, attributes);
             target.setItem(p.toString(), attributes.value);
             return true;
         }

--- a/test/cookie-storage.ts
+++ b/test/cookie-storage.ts
@@ -80,11 +80,14 @@ test(category + 'clear', fixture(dummyDocument, () => {
   assert(document.cookie === 'a=;expires=Thu, 01 Jan 1970 00:00:00 GMT');
 }));
 
-test(category + 'setByIndex', fixture(dummyDocument, () =>{
-  document.cookie = '';
+//proxy "get" tests
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/get
+
+test(category + 'getByIndexNumber', fixture(dummyDocument, () =>{
+  document.cookie ='1=a;2=b';
   const storage = new CookieStorage();
-  storage['a'] = '1';
-  assert(document.cookie === 'a=1');
+  assert(storage[1] === 'a');
+  assert(storage[2] === 'b');
 }));
 
 test(category + 'getByIndex', fixture(dummyDocument, () =>{
@@ -94,6 +97,30 @@ test(category + 'getByIndex', fixture(dummyDocument, () =>{
   assert(storage['b'] === '2');
 }));
 
+test(category + 'getInherited', fixture(dummyDocument, () =>{
+  document.cookie ='a=1;b=2';
+  const storage = new CookieStorage();
+  assert(Object.create(storage)["a"] === '1');
+  assert(Object.create(storage)["b"] === '2');
+}));
+
+test(category + 'getReflect', fixture(dummyDocument, () =>{
+  document.cookie ='a=1;b=2';
+  const storage = new CookieStorage();
+  assert(Reflect.get(storage, "a") === '1');
+  assert(Reflect.get(storage, "b") === '2');
+}));
+
+//proxy "set" tests
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/set
+
+test(category + 'setByIndex', fixture(dummyDocument, () =>{
+  document.cookie = '';
+  const storage = new CookieStorage();
+  storage['a'] = '1';
+  assert(document.cookie === 'a=1');
+}));
+
 test(category + 'setByIndexNumber', fixture(dummyDocument, () =>{
   document.cookie = '';
   const storage = new CookieStorage();
@@ -101,12 +128,141 @@ test(category + 'setByIndexNumber', fixture(dummyDocument, () =>{
   assert(document.cookie === '1=a');
 }));
 
-test(category + 'getByIndexNumber', fixture(dummyDocument, () =>{
-  document.cookie ='1=a;2=b';
+test(category + 'setInherited', fixture(dummyDocument, () =>{
+  document.cookie = '';
   const storage = new CookieStorage();
-  assert(storage[1] === 'a');
-  assert(storage[2] === 'b');
+  Object.create(storage)['a'] = '1';
+  assert(document.cookie === 'a=1');
 }));
+
+test(category + 'setReflect', fixture(dummyDocument, () =>{
+  document.cookie = '';
+  const storage = new CookieStorage();
+  Reflect.set(storage, 'a', '1');
+  assert(document.cookie === 'a=1');
+}));
+
+//proxy "has" tests
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/has
+
+test(category + 'inOperator', fixture(dummyDocument, () =>{
+  document.cookie = "a=1";
+  const storage = new CookieStorage();
+  assert('a' in storage === true);
+}));
+
+test(category + 'inOperatorWithBuiltinFunction', fixture(dummyDocument, () =>{
+  const storage = new CookieStorage();
+  assert('getItem' in storage === true);
+}));
+
+test(category + 'inOperatorInherited', fixture(dummyDocument, () =>{
+  document.cookie = "a=1";
+  const storage = new CookieStorage();
+  assert('a' in Object.create(storage) === true);
+}));
+
+test(category + 'reflectHas', fixture(dummyDocument, () =>{
+  document.cookie = "a=1";
+  const storage = new CookieStorage();
+  assert(Reflect.has(storage, 'a') === true);
+}));
+
+//proxy "delete" tests
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/deleteProperty
+
+test(category + 'deleteOperator', fixture(dummyDocument, () =>{
+  const storage = new CookieStorage();
+  delete storage['a'];
+  assert(storage['a'] === undefined);
+  assert(document.cookie === 'a=;expires=Thu, 01 Jan 1970 00:00:00 GMT');
+}));
+
+test(category + 'deleteReflect', fixture(dummyDocument, () =>{
+  const storage = new CookieStorage();
+  Reflect.deleteProperty(storage,'a');
+  assert(storage['a'] === undefined);
+  assert(document.cookie === 'a=;expires=Thu, 01 Jan 1970 00:00:00 GMT');
+}));
+
+//proxy "defineProperty" tests
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/defineProperty
+
+test(category + 'defineProperty', fixture(dummyDocument, () =>{
+  document.cookie = '';
+  const storage = new CookieStorage();
+  Object.defineProperty(storage, 'a', '1')
+  assert(document.cookie === 'a=1');
+}));
+
+test(category + 'definePropertyReflect', fixture(dummyDocument, () =>{
+  document.cookie = '';
+  const storage = new CookieStorage();
+  Reflect.defineProperty(storage, 'a', '1')
+  assert(document.cookie === 'a=1');
+}));
+
+//proxy "ownKeys" tests
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys
+
+test(category + 'getOwnPropertyNames', fixture(dummyDocument, () =>{
+  document.cookie = "a=1;b=2";
+  const storage = new CookieStorage();
+  const propertyNames = Object.getOwnPropertyNames(storage);
+  assert(propertyNames.length === 2);
+  assert(propertyNames[0] === 'a');
+  assert(propertyNames[1] === 'b');
+}));
+
+test(category + 'objectKeys', fixture(dummyDocument, () =>{
+  document.cookie = "a=1;b=2";
+  const storage = new CookieStorage();
+  const keys = Object.keys(storage);
+  assert(keys.length === 2);
+  assert(keys[0] === 'a');
+  assert(keys[1] === 'b');
+}));
+
+test(category + 'reflectOwnKeys', fixture(dummyDocument, () =>{
+  document.cookie =  "a=1;b=2";
+  const storage = new CookieStorage();
+  const keys = Reflect.ownKeys(storage);
+  assert(keys.length === 2);
+  assert(keys[0] === 'a');
+  assert(keys[1] === 'b');
+}));
+
+//proxy "getOwnPropertyDescriptor" tests
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/getOwnPropertyDescriptor
+
+test(category + 'getOwnPropertyDescriptorOnProperty', fixture(dummyDocument, () =>{
+  document.cookie = "a=1";
+  const storage = new CookieStorage();
+  const descriptor = Object.getOwnPropertyDescriptor(storage,"a");
+  assert(descriptor.value === '1');
+  assert(descriptor.writable === true);
+  assert(descriptor.enumerable === true);
+  assert(descriptor.configurable === true);
+}));
+
+test(category + 'getOwnPropertyDescriptorOnFunction', fixture(dummyDocument, () =>{
+  const storage = new CookieStorage();
+  const descriptor = Object.getOwnPropertyDescriptor(storage,"getItem");
+  assert(descriptor === undefined);
+}));
+
+test(category + 'getOwnPropertyDescriptorReflect', fixture(dummyDocument, () =>{
+  document.cookie = "a=1";
+  const storage = new CookieStorage();
+  const descriptor = Reflect.getOwnPropertyDescriptor(storage,"a");
+  assert(descriptor.value === '1');
+  assert(descriptor.writable === true);
+  assert(descriptor.enumerable === true);
+  assert(descriptor.configurable === true);
+}));
+
+//proxy "preventExtensions" tests
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/preventExtensions
 
 test(category + 'preventExtensions', fixture(dummyDocument, () =>{
   const storage = new CookieStorage();
@@ -136,59 +292,13 @@ test(category + 'preventExtensionsBlocksDefineProperty', fixture(dummyDocument, 
   assert(expectedError.message === "Can't add property a, object is not extensible");
 }));
 
-test(category + 'deleteOperator', fixture(dummyDocument, () =>{
-  const storage = new CookieStorage();
-  delete storage['a'];
-  assert(storage['a'] === undefined);
-  assert(document.cookie === 'a=;expires=Thu, 01 Jan 1970 00:00:00 GMT');
-}));
+//proxy enumeration test
 
-test(category + 'hasOperator', fixture(dummyDocument, () =>{
-  document.cookie = "a=1";
-  const storage = new CookieStorage();
-  assert('a' in storage === true);
-}));
-
-//Object.getOwnPropertyNames()
 test(category + 'getOwnPropertyNames', fixture(dummyDocument, () =>{
   document.cookie = "a=1;b=2";
+  const testnames = ['a', 'b'];
   const storage = new CookieStorage();
-  const propertyNames = Object.getOwnPropertyNames(storage);
-  assert(propertyNames.length === 2);
-  assert(propertyNames[0] === 'a');
-  assert(propertyNames[1] === 'b');
+  for (var name in storage) {
+    assert(testnames.indexOf(name) > -1);
+  }
 }));
-
-//Object.keys()
-test(category + 'objectKeys', fixture(dummyDocument, () =>{
-  document.cookie = "a=1;b=2";
-  const storage = new CookieStorage();
-  const keys = Object.keys(storage);
-  assert(keys.length === 2);
-  assert(keys[0] === 'a');
-  assert(keys[1] === 'b');
-}));
-
-test(category + 'getOwnPropertyDescriptorOnProperty', fixture(dummyDocument, () =>{
-  document.cookie = "a=1;b=2";
-  const storage = new CookieStorage();
-  const descriptor = Object.getOwnPropertyDescriptor(storage,"a");
-  assert(descriptor.value === '1');
-  assert(descriptor.writable === true);
-  assert(descriptor.enumerable === true);
-  assert(descriptor.configurable === true);
-}));
-
-test(category + 'getOwnPropertyDescriptorOnFunction', fixture(dummyDocument, () =>{
-  const storage = new CookieStorage();
-  const descriptor = Object.getOwnPropertyDescriptor(storage,"getItem");
-  assert(descriptor === undefined);
-}));
-
-//Todo: this illustrates a wierdness in the current implmentation - define property is actually creating a property on the proxy object, but other methods of defining properties are not. I should remove this test after solving that.
-// test(category + 'hasOperatorAfterDefineProperty', fixture(dummyDocument, () =>{
-//   const storage = new CookieStorage();
-//   Object.defineProperty(storage, "b", {value: "2"});
-//   assert('b' in storage === true);
-// }));
-

--- a/test/cookie-storage.ts
+++ b/test/cookie-storage.ts
@@ -191,14 +191,14 @@ test(category + 'deleteReflect', fixture(dummyDocument, () =>{
 test(category + 'defineProperty', fixture(dummyDocument, () =>{
   document.cookie = '';
   const storage = new CookieStorage();
-  Object.defineProperty(storage, 'a', '1')
+  Object.defineProperty(storage, 'a', {value: '1'});
   assert(document.cookie === 'a=1');
 }));
 
 test(category + 'definePropertyReflect', fixture(dummyDocument, () =>{
   document.cookie = '';
   const storage = new CookieStorage();
-  Reflect.defineProperty(storage, 'a', '1')
+  Reflect.defineProperty(storage, 'a', {value: '1'});
   assert(document.cookie === 'a=1');
 }));
 

--- a/test/cookie-storage.ts
+++ b/test/cookie-storage.ts
@@ -164,15 +164,31 @@ test(category + 'objectKeys', fixture(dummyDocument, () =>{
   document.cookie = "a=1;b=2";
   const storage = new CookieStorage();
   const keys = Object.keys(storage);
-  assert(keys.length === 0); //Todo: this should really be 2. Need to investigate why it's failing
-  //assert(keys[0] === 'a');
-  //assert(keys[1] === 'b');
+  assert(keys.length === 2);
+  assert(keys[0] === 'a');
+  assert(keys[1] === 'b');
+}));
+
+test(category + 'getOwnPropertyDescriptorOnProperty', fixture(dummyDocument, () =>{
+  document.cookie = "a=1;b=2";
+  const storage = new CookieStorage();
+  const descriptor = Object.getOwnPropertyDescriptor(storage,"a");
+  assert(descriptor.value === '1');
+  assert(descriptor.writable === true);
+  assert(descriptor.enumerable === true);
+  assert(descriptor.configurable === true);
+}));
+
+test(category + 'getOwnPropertyDescriptorOnFunction', fixture(dummyDocument, () =>{
+  const storage = new CookieStorage();
+  const descriptor = Object.getOwnPropertyDescriptor(storage,"getItem");
+  assert(descriptor === undefined);
 }));
 
 //Todo: this illustrates a wierdness in the current implmentation - define property is actually creating a property on the proxy object, but other methods of defining properties are not. I should remove this test after solving that.
-test(category + 'hasOperatorAfterDefineProperty', fixture(dummyDocument, () =>{
-  const storage = new CookieStorage();
-  Object.defineProperty(storage, "b", {value: "2"});
-  assert('b' in storage === true);
-}));
+// test(category + 'hasOperatorAfterDefineProperty', fixture(dummyDocument, () =>{
+//   const storage = new CookieStorage();
+//   Object.defineProperty(storage, "b", {value: "2"});
+//   assert('b' in storage === true);
+// }));
 

--- a/test/cookie-storage.ts
+++ b/test/cookie-storage.ts
@@ -80,3 +80,99 @@ test(category + 'clear', fixture(dummyDocument, () => {
   assert(document.cookie === 'a=;expires=Thu, 01 Jan 1970 00:00:00 GMT');
 }));
 
+test(category + 'setByIndex', fixture(dummyDocument, () =>{
+  document.cookie = '';
+  const storage = new CookieStorage();
+  storage['a'] = '1';
+  assert(document.cookie === 'a=1');
+}));
+
+test(category + 'getByIndex', fixture(dummyDocument, () =>{
+  document.cookie ='a=1;b=2';
+  const storage = new CookieStorage();
+  assert(storage['a'] === '1');
+  assert(storage['b'] === '2');
+}));
+
+test(category + 'setByIndexNumber', fixture(dummyDocument, () =>{
+  document.cookie = '';
+  const storage = new CookieStorage();
+  storage[1] = 'a';
+  assert(document.cookie === '1=a');
+}));
+
+test(category + 'getByIndexNumber', fixture(dummyDocument, () =>{
+  document.cookie ='1=a;2=b';
+  const storage = new CookieStorage();
+  assert(storage[1] === 'a');
+  assert(storage[2] === 'b');
+}));
+
+test(category + 'preventExtensions', fixture(dummyDocument, () =>{
+  const storage = new CookieStorage();
+  Object.preventExtensions(storage);
+  assert(Object.isExtensible(storage) === false);
+}));
+
+test(category + 'preventExtensionsDoesntBlockIndexSetting', fixture(dummyDocument, () =>{
+  document.cookie = '';
+  const storage = new CookieStorage();
+  Object.preventExtensions(storage);
+  storage['a'] = '1';
+  assert(document.cookie === 'a=1');
+}));
+
+test(category + 'preventExtensionsBlocksDefineProperty', fixture(dummyDocument, () =>{
+  const storage = new CookieStorage();
+  Object.preventExtensions(storage);
+  let expectedError = new Error();
+  try {
+    Object.defineProperty(storage,"a",{value: "1"});
+  }
+  catch(e) {
+    expectedError = e;
+  }
+  assert(expectedError.name === "TypeError");
+  assert(expectedError.message === "Can't add property a, object is not extensible");
+}));
+
+test(category + 'deleteOperator', fixture(dummyDocument, () =>{
+  const storage = new CookieStorage();
+  delete storage['a'];
+  assert(storage['a'] === undefined);
+  assert(document.cookie === 'a=;expires=Thu, 01 Jan 1970 00:00:00 GMT');
+}));
+
+test(category + 'hasOperator', fixture(dummyDocument, () =>{
+  document.cookie = "a=1";
+  const storage = new CookieStorage();
+  assert('a' in storage === true);
+}));
+
+//Object.getOwnPropertyNames()
+test(category + 'getOwnPropertyNames', fixture(dummyDocument, () =>{
+  document.cookie = "a=1;b=2";
+  const storage = new CookieStorage();
+  const propertyNames = Object.getOwnPropertyNames(storage);
+  assert(propertyNames.length === 2);
+  assert(propertyNames[0] === 'a');
+  assert(propertyNames[1] === 'b');
+}));
+
+//Object.keys()
+test(category + 'objectKeys', fixture(dummyDocument, () =>{
+  document.cookie = "a=1;b=2";
+  const storage = new CookieStorage();
+  const keys = Object.keys(storage);
+  assert(keys.length === 0); //Todo: this should really be 2. Need to investigate why it's failing
+  //assert(keys[0] === 'a');
+  //assert(keys[1] === 'b');
+}));
+
+//Todo: this illustrates a wierdness in the current implmentation - define property is actually creating a property on the proxy object, but other methods of defining properties are not. I should remove this test after solving that.
+test(category + 'hasOperatorAfterDefineProperty', fixture(dummyDocument, () =>{
+  const storage = new CookieStorage();
+  Object.defineProperty(storage, "b", {value: "2"});
+  assert('b' in storage === true);
+}));
+

--- a/test/cookie-storage.ts
+++ b/test/cookie-storage.ts
@@ -1,6 +1,6 @@
 import * as assert from 'power-assert';
 import beater from 'beater';
-import { CookieStorage } from '../src/';
+import { CookieStorage, ProxyIsSupported } from '../src/cookie-storage';
 
 const { test, fixture } = beater();
 
@@ -80,225 +80,230 @@ test(category + 'clear', fixture(dummyDocument, () => {
   assert(document.cookie === 'a=;expires=Thu, 01 Jan 1970 00:00:00 GMT');
 }));
 
-//proxy "get" tests
-//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/get
+//Test index-related features. These features require that the runtime support the "Proxy" object and won't be present if the runtime does not
+if (ProxyIsSupported()) {
 
-test(category + 'getByIndexNumber', fixture(dummyDocument, () =>{
-  document.cookie ='1=a;2=b';
-  const storage = new CookieStorage();
-  assert(storage[1] === 'a');
-  assert(storage[2] === 'b');
-}));
+  //proxy "get" tests
+  //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/get
 
-test(category + 'getByIndex', fixture(dummyDocument, () =>{
-  document.cookie ='a=1;b=2';
-  const storage = new CookieStorage();
-  assert(storage['a'] === '1');
-  assert(storage['b'] === '2');
-}));
+  test(category + 'getByIndexNumber', fixture(dummyDocument, () =>{
+    document.cookie ='1=a;2=b';
+    const storage = new CookieStorage();
+    assert(storage[1] === 'a');
+    assert(storage[2] === 'b');
+  }));
 
-test(category + 'getInherited', fixture(dummyDocument, () =>{
-  document.cookie ='a=1;b=2';
-  const storage = new CookieStorage();
-  assert(Object.create(storage)["a"] === '1');
-  assert(Object.create(storage)["b"] === '2');
-}));
+  test(category + 'getByIndex', fixture(dummyDocument, () =>{
+    document.cookie ='a=1;b=2';
+    const storage = new CookieStorage();
+    assert(storage['a'] === '1');
+    assert(storage['b'] === '2');
+  }));
 
-test(category + 'getReflect', fixture(dummyDocument, () =>{
-  document.cookie ='a=1;b=2';
-  const storage = new CookieStorage();
-  assert(Reflect.get(storage, "a") === '1');
-  assert(Reflect.get(storage, "b") === '2');
-}));
+  test(category + 'getInherited', fixture(dummyDocument, () =>{
+    document.cookie ='a=1;b=2';
+    const storage = new CookieStorage();
+    assert(Object.create(storage)["a"] === '1');
+    assert(Object.create(storage)["b"] === '2');
+  }));
 
-//proxy "set" tests
-//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/set
+  test(category + 'getReflect', fixture(dummyDocument, () =>{
+    document.cookie ='a=1;b=2';
+    const storage = new CookieStorage();
+    assert(Reflect.get(storage, "a") === '1');
+    assert(Reflect.get(storage, "b") === '2');
+  }));
 
-test(category + 'setByIndex', fixture(dummyDocument, () =>{
-  document.cookie = '';
-  const storage = new CookieStorage();
-  storage['a'] = '1';
-  assert(document.cookie === 'a=1');
-}));
+  //proxy "set" tests
+  //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/set
 
-test(category + 'setByIndexNumber', fixture(dummyDocument, () =>{
-  document.cookie = '';
-  const storage = new CookieStorage();
-  storage[1] = 'a';
-  assert(document.cookie === '1=a');
-}));
+  test(category + 'setByIndex', fixture(dummyDocument, () =>{
+    document.cookie = '';
+    const storage = new CookieStorage();
+    storage['a'] = '1';
+    assert(document.cookie === 'a=1');
+  }));
 
-test(category + 'setInherited', fixture(dummyDocument, () =>{
-  document.cookie = '';
-  const storage = new CookieStorage();
-  Object.create(storage)['a'] = '1';
-  assert(document.cookie === 'a=1');
-}));
+  test(category + 'setByIndexNumber', fixture(dummyDocument, () =>{
+    document.cookie = '';
+    const storage = new CookieStorage();
+    storage[1] = 'a';
+    assert(document.cookie === '1=a');
+  }));
 
-test(category + 'setReflect', fixture(dummyDocument, () =>{
-  document.cookie = '';
-  const storage = new CookieStorage();
-  Reflect.set(storage, 'a', '1');
-  assert(document.cookie === 'a=1');
-}));
+  test(category + 'setInherited', fixture(dummyDocument, () =>{
+    document.cookie = '';
+    const storage = new CookieStorage();
+    Object.create(storage)['a'] = '1';
+    assert(document.cookie === 'a=1');
+  }));
 
-//proxy "has" tests
-//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/has
+  test(category + 'setReflect', fixture(dummyDocument, () =>{
+    document.cookie = '';
+    const storage = new CookieStorage();
+    Reflect.set(storage, 'a', '1');
+    assert(document.cookie === 'a=1');
+  }));
 
-test(category + 'inOperator', fixture(dummyDocument, () =>{
-  document.cookie = "a=1";
-  const storage = new CookieStorage();
-  assert('a' in storage === true);
-}));
+  //proxy "has" tests
+  //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/has
 
-test(category + 'inOperatorWithBuiltinFunction', fixture(dummyDocument, () =>{
-  const storage = new CookieStorage();
-  assert('getItem' in storage === true);
-}));
+  test(category + 'inOperator', fixture(dummyDocument, () =>{
+    document.cookie = "a=1";
+    const storage = new CookieStorage();
+    assert('a' in storage === true);
+  }));
 
-test(category + 'inOperatorInherited', fixture(dummyDocument, () =>{
-  document.cookie = "a=1";
-  const storage = new CookieStorage();
-  assert('a' in Object.create(storage) === true);
-}));
+  test(category + 'inOperatorWithBuiltinFunction', fixture(dummyDocument, () =>{
+    const storage = new CookieStorage();
+    assert('getItem' in storage === true);
+  }));
 
-test(category + 'reflectHas', fixture(dummyDocument, () =>{
-  document.cookie = "a=1";
-  const storage = new CookieStorage();
-  assert(Reflect.has(storage, 'a') === true);
-}));
+  test(category + 'inOperatorInherited', fixture(dummyDocument, () =>{
+    document.cookie = "a=1";
+    const storage = new CookieStorage();
+    assert('a' in Object.create(storage) === true);
+  }));
 
-//proxy "delete" tests
-//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/deleteProperty
+  test(category + 'reflectHas', fixture(dummyDocument, () =>{
+    document.cookie = "a=1";
+    const storage = new CookieStorage();
+    assert(Reflect.has(storage, 'a') === true);
+  }));
 
-test(category + 'deleteOperator', fixture(dummyDocument, () =>{
-  const storage = new CookieStorage();
-  delete storage['a'];
-  assert(storage['a'] === undefined);
-  assert(document.cookie === 'a=;expires=Thu, 01 Jan 1970 00:00:00 GMT');
-}));
+  //proxy "delete" tests
+  //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/deleteProperty
 
-test(category + 'deleteReflect', fixture(dummyDocument, () =>{
-  const storage = new CookieStorage();
-  Reflect.deleteProperty(storage,'a');
-  assert(storage['a'] === undefined);
-  assert(document.cookie === 'a=;expires=Thu, 01 Jan 1970 00:00:00 GMT');
-}));
+  test(category + 'deleteOperator', fixture(dummyDocument, () =>{
+    const storage = new CookieStorage();
+    delete storage['a'];
+    assert(storage['a'] === undefined);
+    assert(document.cookie === 'a=;expires=Thu, 01 Jan 1970 00:00:00 GMT');
+  }));
 
-//proxy "defineProperty" tests
-//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/defineProperty
+  test(category + 'deleteReflect', fixture(dummyDocument, () =>{
+    const storage = new CookieStorage();
+    Reflect.deleteProperty(storage,'a');
+    assert(storage['a'] === undefined);
+    assert(document.cookie === 'a=;expires=Thu, 01 Jan 1970 00:00:00 GMT');
+  }));
 
-test(category + 'defineProperty', fixture(dummyDocument, () =>{
-  document.cookie = '';
-  const storage = new CookieStorage();
-  Object.defineProperty(storage, 'a', {value: '1'});
-  assert(document.cookie === 'a=1');
-}));
+  //proxy "defineProperty" tests
+  //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/defineProperty
 
-test(category + 'definePropertyReflect', fixture(dummyDocument, () =>{
-  document.cookie = '';
-  const storage = new CookieStorage();
-  Reflect.defineProperty(storage, 'a', {value: '1'});
-  assert(document.cookie === 'a=1');
-}));
+  test(category + 'defineProperty', fixture(dummyDocument, () =>{
+    document.cookie = '';
+    const storage = new CookieStorage();
+    Object.defineProperty(storage, 'a', {value: '1'});
+    assert(document.cookie === 'a=1');
+  }));
 
-//proxy "ownKeys" tests
-//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys
+  test(category + 'definePropertyReflect', fixture(dummyDocument, () =>{
+    document.cookie = '';
+    const storage = new CookieStorage();
+    Reflect.defineProperty(storage, 'a', {value: '1'});
+    assert(document.cookie === 'a=1');
+  }));
 
-test(category + 'getOwnPropertyNames', fixture(dummyDocument, () =>{
-  document.cookie = "a=1;b=2";
-  const storage = new CookieStorage();
-  const propertyNames = Object.getOwnPropertyNames(storage);
-  assert(propertyNames.length === 2);
-  assert(propertyNames[0] === 'a');
-  assert(propertyNames[1] === 'b');
-}));
+  //proxy "ownKeys" tests
+  //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys
 
-test(category + 'objectKeys', fixture(dummyDocument, () =>{
-  document.cookie = "a=1;b=2";
-  const storage = new CookieStorage();
-  const keys = Object.keys(storage);
-  assert(keys.length === 2);
-  assert(keys[0] === 'a');
-  assert(keys[1] === 'b');
-}));
+  test(category + 'getOwnPropertyNames', fixture(dummyDocument, () =>{
+    document.cookie = "a=1;b=2";
+    const storage = new CookieStorage();
+    const propertyNames = Object.getOwnPropertyNames(storage);
+    assert(propertyNames.length === 2);
+    assert(propertyNames[0] === 'a');
+    assert(propertyNames[1] === 'b');
+  }));
 
-test(category + 'reflectOwnKeys', fixture(dummyDocument, () =>{
-  document.cookie =  "a=1;b=2";
-  const storage = new CookieStorage();
-  const keys = Reflect.ownKeys(storage);
-  assert(keys.length === 2);
-  assert(keys[0] === 'a');
-  assert(keys[1] === 'b');
-}));
+  test(category + 'objectKeys', fixture(dummyDocument, () =>{
+    document.cookie = "a=1;b=2";
+    const storage = new CookieStorage();
+    const keys = Object.keys(storage);
+    assert(keys.length === 2);
+    assert(keys[0] === 'a');
+    assert(keys[1] === 'b');
+  }));
 
-//proxy "getOwnPropertyDescriptor" tests
-//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/getOwnPropertyDescriptor
+  test(category + 'reflectOwnKeys', fixture(dummyDocument, () =>{
+    document.cookie =  "a=1;b=2";
+    const storage = new CookieStorage();
+    const keys = Reflect.ownKeys(storage);
+    assert(keys.length === 2);
+    assert(keys[0] === 'a');
+    assert(keys[1] === 'b');
+  }));
 
-test(category + 'getOwnPropertyDescriptorOnProperty', fixture(dummyDocument, () =>{
-  document.cookie = "a=1";
-  const storage = new CookieStorage();
-  const descriptor = Object.getOwnPropertyDescriptor(storage,"a");
-  assert(descriptor.value === '1');
-  assert(descriptor.writable === true);
-  assert(descriptor.enumerable === true);
-  assert(descriptor.configurable === true);
-}));
+  //proxy "getOwnPropertyDescriptor" tests
+  //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/getOwnPropertyDescriptor
 
-test(category + 'getOwnPropertyDescriptorOnFunction', fixture(dummyDocument, () =>{
-  const storage = new CookieStorage();
-  const descriptor = Object.getOwnPropertyDescriptor(storage,"getItem");
-  assert(descriptor === undefined);
-}));
+  test(category + 'getOwnPropertyDescriptorOnProperty', fixture(dummyDocument, () =>{
+    document.cookie = "a=1";
+    const storage = new CookieStorage();
+    const descriptor = Object.getOwnPropertyDescriptor(storage,"a");
+    assert(descriptor.value === '1');
+    assert(descriptor.writable === true);
+    assert(descriptor.enumerable === true);
+    assert(descriptor.configurable === true);
+  }));
 
-test(category + 'getOwnPropertyDescriptorReflect', fixture(dummyDocument, () =>{
-  document.cookie = "a=1";
-  const storage = new CookieStorage();
-  const descriptor = Reflect.getOwnPropertyDescriptor(storage,"a");
-  assert(descriptor.value === '1');
-  assert(descriptor.writable === true);
-  assert(descriptor.enumerable === true);
-  assert(descriptor.configurable === true);
-}));
+  test(category + 'getOwnPropertyDescriptorOnFunction', fixture(dummyDocument, () =>{
+    const storage = new CookieStorage();
+    const descriptor = Object.getOwnPropertyDescriptor(storage,"getItem");
+    assert(descriptor === undefined);
+  }));
 
-//proxy "preventExtensions" tests
-//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/preventExtensions
+  test(category + 'getOwnPropertyDescriptorReflect', fixture(dummyDocument, () =>{
+    document.cookie = "a=1";
+    const storage = new CookieStorage();
+    const descriptor = Reflect.getOwnPropertyDescriptor(storage,"a");
+    assert(descriptor.value === '1');
+    assert(descriptor.writable === true);
+    assert(descriptor.enumerable === true);
+    assert(descriptor.configurable === true);
+  }));
 
-test(category + 'preventExtensions', fixture(dummyDocument, () =>{
-  const storage = new CookieStorage();
-  Object.preventExtensions(storage);
-  assert(Object.isExtensible(storage) === false);
-}));
+  //proxy "preventExtensions" tests
+  //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/preventExtensions
 
-test(category + 'preventExtensionsDoesntBlockIndexSetting', fixture(dummyDocument, () =>{
-  document.cookie = '';
-  const storage = new CookieStorage();
-  Object.preventExtensions(storage);
-  storage['a'] = '1';
-  assert(document.cookie === 'a=1');
-}));
+  test(category + 'preventExtensions', fixture(dummyDocument, () =>{
+    const storage = new CookieStorage();
+    Object.preventExtensions(storage);
+    assert(Object.isExtensible(storage) === false);
+  }));
 
-test(category + 'preventExtensionsBlocksDefineProperty', fixture(dummyDocument, () =>{
-  const storage = new CookieStorage();
-  Object.preventExtensions(storage);
-  let expectedError = new Error();
-  try {
-    Object.defineProperty(storage,"a",{value: "1"});
-  }
-  catch(e) {
-    expectedError = e;
-  }
-  assert(expectedError.name === "TypeError");
-  assert(expectedError.message === "Can't add property a, object is not extensible");
-}));
+  test(category + 'preventExtensionsDoesntBlockIndexSetting', fixture(dummyDocument, () =>{
+    document.cookie = '';
+    const storage = new CookieStorage();
+    Object.preventExtensions(storage);
+    storage['a'] = '1';
+    assert(document.cookie === 'a=1');
+  }));
 
-//proxy enumeration test
+  test(category + 'preventExtensionsBlocksDefineProperty', fixture(dummyDocument, () =>{
+    const storage = new CookieStorage();
+    Object.preventExtensions(storage);
+    let expectedError = new Error();
+    try {
+      Object.defineProperty(storage,"a",{value: "1"});
+    }
+    catch(e) {
+      expectedError = e;
+    }
+    assert(expectedError.name === "TypeError");
+    assert(expectedError.message === "Can't add property a, object is not extensible");
+  }));
 
-test(category + 'getOwnPropertyNames', fixture(dummyDocument, () =>{
-  document.cookie = "a=1;b=2";
-  const testnames = ['a', 'b'];
-  const storage = new CookieStorage();
-  for (var name in storage) {
-    assert(testnames.indexOf(name) > -1);
-  }
-}));
+  //proxy enumeration test
+
+  test(category + 'getOwnPropertyNames', fixture(dummyDocument, () =>{
+    document.cookie = "a=1;b=2";
+    const testnames = ['a', 'b'];
+    const storage = new CookieStorage();
+    for (var name in storage) {
+      assert(testnames.indexOf(name) > -1);
+    }
+  }));
+
+}


### PR DESCRIPTION
This change adds support for property indexing on CookieStorage, as discussed in #5. The basic use case is:
```
var myCookieStorage = new CookieStorage();
myCookieStorage['mykey'] = 'myvalue';
var cookieValue = myCookieStorage['mykey']; //this will be 'myvalue'!
```
Since implementing this required using a `Proxy` object (see [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy)), I went ahead and did a complete implementation (following the spec) with the goal of matching the behavior of `localStorage` and `sessionStorage`. As a result, the following property-related operations will also work:

- `'mykey' in myCookieStorage == true;`
- `delete myCookieStorage['mykey'];`
- `Object.defineProperty(myCookieStorage,'myKey','myValue');`
- `Object.keys(myCookieStorage) `<- returns an array of all keys
- `for (key name in storage) { /*do something with key*/ }`
- `Reflect` object operations.